### PR TITLE
fix version import

### DIFF
--- a/flake8_pylint/_plugin.py
+++ b/flake8_pylint/_plugin.py
@@ -1,10 +1,10 @@
 # built-in
 from ast import AST
+from importlib.metadata import metadata
 from tokenize import TokenInfo
 from typing import Sequence
 
 # external
-from pylint.__pkginfo__ import version
 from pylint.lint import Run
 from pylint.reporters import BaseReporter
 
@@ -40,7 +40,7 @@ class Reporter(BaseReporter):
 
 class PyLintChecker:
     name = 'pylint'
-    version = version
+    version = metadata(name)
 
     def __init__(self, tree: AST, file_tokens: Sequence[TokenInfo], filename: str = STDIN) -> None:
         self.tree = tree


### PR DESCRIPTION
According to [2.8 changes of pylint](https://github.com/PyCQA/pylint/blob/822b99e1260417c3141fa947e65237e40d1bfa8b/doc/whatsnew/2.8.rst) , we now have to import the version using `importlib`.

0.1.1 is currently broken. This patch fixes it.