### PR TITLE
Set max supported flake8 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ home-page = "https://github.com/orsinium-labs/flake8-pylint"
 description-file = "README.md"
 requires-python = ">=3.6"
 keywords = "flake8,plugins,pylint,introspection,linter"
-requires = ["flake8", "pylint"]
+requires = [
+    "flake8<6.0.0",  # Flake8 dropped support for 4 difit pylint codes, https://github.com/PyCQA/flake8/issues/1759
+    "pylint"
+    ]
 
 classifiers=[
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
In the latest release, flake8 forbids to use of error codes produced by this plugin (4 digits), which makes the plugin hard to use. https://github.com/PyCQA/flake8/issues/1759

This is a quick fix to avoid confusing troubles.  Not sure that it's enough.

@orsinium if you plan to do something about it, I can try to help with ideas and code.

