### PR TITLE
Breaking: Flake8 6.0.0 compatibility

### DIFF
--- a/flake8_pylint/_plugin.py
+++ b/flake8_pylint/_plugin.py
@@ -35,6 +35,9 @@ except ImportError:
 
 
 class Reporter(BaseReporter):
+    """PyLint reporter that memorizes all errors to be reported without printing them.
+    """
+
     def __init__(self) -> None:
         self.errors: list[dict[str, Any]] = []
         super().__init__()
@@ -46,12 +49,19 @@ class Reporter(BaseReporter):
         # ignore `invalid syntax` messages, it is already checked by `pycodestyle`
         if msg.msg_id == 'E0001':
             return
+
+        # flake8 stopped supporting 4-digit error codes,
+        # so we drop the first digit of the code.
+        # https://github.com/PyCQA/flake8/issues/1759
+        code = msg.msg_id[0] + msg.msg_id[2:]
+        assert len(code) == 4
+
         self.errors.append(dict(
             row=msg.line,
             col=msg.column,
             text='{prefix}{id} {msg} ({symbol})'.format(
                 prefix=PREFIX,
-                id=msg.msg_id,
+                id=code,
                 msg=msg.msg or '',
                 symbol=msg.symbol,
             ),
@@ -60,6 +70,8 @@ class Reporter(BaseReporter):
 
 
 class PyLintChecker:
+    """The flake8 plugin entry point.
+    """
     name = 'pylint'
     version = VERSION
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description-file = "README.md"
 requires-python = ">=3.6"
 keywords = "flake8,plugins,pylint,introspection,linter"
 requires = [
-    "flake8<6.0.0",  # Flake8 dropped support for 4 difit pylint codes, https://github.com/PyCQA/flake8/issues/1759
+    "flake8",
     "pylint",
 ]
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -23,7 +23,7 @@ def test_smoke(tmp_path: Path) -> None:
     assert len(msgs) == 3
     for msg in msgs:
         assert 'example.py:' in msg
-        assert ':1: PLC0' in msg
-    assert 'PLC0114 Missing module docstring (missing-module-docstring)' in msgs[0]
-    assert 'PLC0116 Missing function or method docstring' in msgs[1]
-    assert 'PLC0103 Function name "f"' in msgs[2]
+        assert ':1: PLC' in msg
+    assert 'PLC114 Missing module docstring (missing-module-docstring)' in msgs[0]
+    assert 'PLC116 Missing function or method docstring' in msgs[1]
+    assert 'PLC103 Function name "f"' in msgs[2]


### PR DESCRIPTION
Flake8 6.0.0 introduced limitations on the error codes that can be used in `ignore` in config. The error codes cannot contain 4 digits anymore. See #2.

The PR changes the error codes for all violations by removing the first digit from all codes. So, `PLC0114` is replaced with `PLC114`. It causes overlaps for some error codes, but not many. I wish I had a better solution.

If you want to ignore an error reported by the plugin, I suggest using the means provided by pylint rather than flake8 codes. For example, use `# pylint: disable=` comment instead of `# noqa:`. That way, you don't depend on flake8-pylint and can migrate to the bare-bones pylint without any troubles if one day you decide to. I provide flake8-pylint for your convenience, not to make you dependent on it :)

